### PR TITLE
Refactor Subtractor - Use let instead of var for oscillator - Use ternary for Infinity-gaurd so interval is `const` - Remove or note unused code - Rescope constants - Document constants - Rename functions by action and type - Create separate handleKeys() function - Make startPolyNote() more functional - startPolyNote() returns its oscillators[] to handleKeys()

### DIFF
--- a/src/Subtractor.js
+++ b/src/Subtractor.js
@@ -1,87 +1,79 @@
 import { Osc } from './Osc'
-import key_to_freq from './utils/key_to_freq'
 
 class Subtractor {
   constructor() {
     console.log('Subtractor constructed')
-    const osc1 = new Osc()
+    const osc1 = new Osc()  // unused atm
     this.context = new AudioContext()
 
-    this.oscillator = this.context.createOscillator();
+    this.octave = 5.1   // floats work for this which is cool
+    this.polyphony = 3  // integer between 1 and 10
+    this.detune = 2     // float, between 0 and 1 is a half-step
 
-    const octaveKeys = new Map([
-      ['a', 0],
-      ['w', 1],
-      ['s', 2],
-      ['e', 3],
-      ['d', 4],
-      ['f', 5],
-      ['t', 6],
-      ['g', 7],
-      ['y', 8],
-      ['h', 9],
-      ['u', 10],
-      ['j', 11],
-      ['k', 0]
-    ])
+    this.handleKeys()
+  }
 
+  handleKeys() {
+    window.addEventListener('keydown', (eDown) => {
+      const octaveKeys = new Map([
+        ['a', 0],
+        ['w', 1],
+        ['s', 2],
+        ['e', 3],
+        ['d', 4],
+        ['f', 5],
+        ['t', 6],
+        ['g', 7],
+        ['y', 8],
+        ['h', 9],
+        ['u', 10],
+        ['j', 11],
+        ['k', 12]
+      ])
+      if (octaveKeys.has(eDown.key)) {
+        const note = octaveKeys.get(eDown.key) + (this.octave * 12)
+        const oscillators = this.startPolyNote(note)
 
-    this.octave = 6
-    this.polyphony = 3 // between 1 and 10
-    this.detune = .5 // between 0 and 1
-
-    window.addEventListener('keydown', (e) => {
-      if (octaveKeys.has(e.key)) {
-        const note = octaveKeys.get(e.key) + (this.octave * 12)
-        
-        this.playNote(note, e.key)
+        // on keyup, stop the oscillators
+        const stopOscillators = function(eUp) {
+          if (eDown.key === eUp.key) {
+            oscillators.forEach(osc => osc.stop())
+            window.removeEventListener('keyup', stopOscillators)
+          }
+        }
+        window.addEventListener('keyup', stopOscillators)
       }
 
-      if (e.key == 'z' && this.octave > 0) {
+      if (eDown.key == 'z' && this.octave > 0) {
         this.octave--;
       }
-      if (e.key == 'x' && this.octave < 12) {
+      if (eDown.key == 'x' && this.octave < 12) {
         this.octave++;
       }
     })
-
-    window.addEventListener('keyup', (e) => {
-      try {
-        this.oscillator.stop();
-      } catch(e) {
-        // do nothing
-      }
-    })
   }
 
-  playNote(note, key) {
+  startPolyNote(note, key) {
+    // how far below the root note to start adding detuned notes
     const noteOffset = Math.floor((this.polyphony - 1) / 2) * -1
+    // number of intervals on the upper side of the root note
     const numIntervals = Math.floor(this.polyphony / 2)
-    let interval = this.detune / numIntervals
+    // width of interval based on the detune and polyphony measured in notes
+    const interval = numIntervals == 0
+      ? 0
+      : this.detune / numIntervals
+      // ternary gaurds interval being Infinity
 
-    if (interval == Infinity) {
-      interval = 0
-    }
-
-    let notes = []
-    for (var i = 0; i < this.polyphony; i++) {
-       notes.push(note + (i + noteOffset) * interval)
-    }
-    let freqs = notes.map(this.getNoteFreq)
-    let oscs = freqs.map(this.playFreq.bind(this))
-
-    const fn = function(e) {
-      if (e.key === key) {
-        oscs.forEach(osc => osc.stop())
-        window.removeEventListener('keyup', fn)
-      }
-    }
-
-    window.addEventListener('keyup', fn)
+    // create n=polyphony oscillators
+    return Array(this.polyphony).fill()
+      // notes starting at the offset are spread by interval
+      .map((_,i) => note + (noteOffset + i) * interval)
+      .map(this.getNoteFreq)
+      .map(this.startFreqOscillator.bind(this))
   }
-
-  playFreq(freq) {
-    var oscillator = this.context.createOscillator()
+  
+  startFreqOscillator(freq) {
+    let oscillator = this.context.createOscillator()
     oscillator.type = 'sawtooth';
     oscillator.frequency.value = freq;
     oscillator.connect(this.context.destination);


### PR DESCRIPTION
- Use let instead of var for oscillator
- Use ternary for Infinity-gaurd so interval is `const`
- Remove or note unused code
- Rescope constants
- Document constants
- Rename functions by action and type
- Create separate handleKeys() function
- Make startPolyNote() more functional
- startPolyNote() returns its oscillators[] to handleKeys()