### PR TITLE
2-way binding with Observer pattern

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -202,7 +202,7 @@
         "no-throw-literal": "error",
         "no-undef-init": "error",
         "no-undefined": "error",
-        "no-underscore-dangle": "error",
+        "no-underscore-dangle": "off",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",
@@ -242,7 +242,7 @@
         "prefer-rest-params": "error",
         "prefer-spread": "error",
         "prefer-template": "error",
-        "quote-props": "error",
+        "quote-props": "off",
         "quotes": [
             "error",
             "single"

--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@
           </optgroup>
           <optgroup label="Bass">
             <option value="ElectroFifth">Electro Fifth</option>
-            <option value="DarkBass">Dark bass</option>
+            <option value="DarkBass">Dark Bass</option>
           </optgroup>
         </select>
         <button onclick="subtractor.loadPresetFile()">Load</button>
@@ -86,31 +86,31 @@
     </div>
     <section>
       <h2>Super</h2>
-      <x-knob id="polyphony" name="Poly" value="1" min="1" max="10" oninput="subtractor.setPolyphony(value)"></x-knob>
-      <x-knob id="detune" name="Detune" value="0" min="0" max="100" oninput="subtractor.setDetune(value)"></x-knob>
+      <x-knob id="polyphony" name="Poly" value="1" min="1" max="10" observe="subtractor" bind="polyphony"></x-knob>
+      <x-knob id="detune" name="Detune" value="0" min="0" max="100" observe="subtractor" bind="detune"></x-knob>
     </section>
     <section>
       <h2>Osc 1</h2>
-      <x-knob id="enabled" name="On" value="1" min="0" max="1" oninput="subtractor.osc1.setEnabled(value)"></x-knob>
-      <x-knob id="waveform" name="Waveform" value="3" min="1" max="4" oninput="subtractor.osc1.setWaveform(value)"></x-knob>      
-      <x-knob id="octave" name="Octave" value="0" min="-5" max="5" oninput="subtractor.osc1.setOctave(value)"></x-knob>
-      <x-knob id="semi" name="Semi" value="0" min="-12" max="12" oninput="subtractor.osc1.setSemi(value)"></x-knob>
-      <x-knob id="cent" name="Cent" value="0" min="0" max="100" oninput="subtractor.osc1.setDetune(value)"></x-knob>
+      <x-knob id="enabled" name="On" value="1" min="0" max="1" observe="subtractor.osc1" bind="enabled"></x-knob>
+      <x-knob id="waveform" name="Waveform" value="3" min="1" max="4" observe="subtractor.osc1" bind="waveform"></x-knob> 
+      <x-knob id="octave" name="Octave" value="0" min="-5" max="5" observe="subtractor.osc1" bind="octave"></x-knob>
+      <x-knob id="semi" name="Semi" value="0" min="-12" max="12" observe="subtractor.osc1" bind="semi"></x-knob>
+      <x-knob id="cent" name="Cent" value="0" min="0" max="100" observe="subtractor.osc1" bind="detune"></x-knob>
     </section>
     <section>
       <h2>Osc 2</h2>
-      <x-knob id="enabled" name="On" value="0" min="0" max="1" oninput="subtractor.osc2.setEnabled(value)"></x-knob>
-      <x-knob id="waveform" name="Waveform" value="3" min="1" max="4" oninput="subtractor.osc2.setWaveform(value)"></x-knob> 
-      <x-knob id="octave" name="Octave" value="0" min="-5" max="5" oninput="subtractor.osc2.setOctave(value)"></x-knob>
-      <x-knob id="semi" name="Semi" value="0" min="-12" max="12" oninput="subtractor.osc2.setSemi(value)"></x-knob>
-      <x-knob id="cent" name="Cent" value="0" min="0" max="100" oninput="subtractor.osc2.setDetune(value)"></x-knob>
+      <x-knob id="enabled" name="On" value="0" min="0" max="1" observe="subtractor.osc2" bind="enabled"></x-knob>
+      <x-knob id="waveform" name="Waveform" value="3" min="1" max="4" observe="subtractor.osc2" bind="waveform"></x-knob> 
+      <x-knob id="octave" name="Octave" value="0" min="-5" max="5" observe="subtractor.osc2" bind="octave"></x-knob>
+      <x-knob id="semi" name="Semi" value="0" min="-12" max="12" observe="subtractor.osc2" bind="semi"></x-knob>
+      <x-knob id="cent" name="Cent" value="0" min="0" max="100" observe="subtractor.osc2" bind="detune"></x-knob>
     </section>
     <section>
       <h2>Filter</h2>
-      <x-knob id="filter-type" name="Fiter Type" value="1" min="1" max="8" oninput="subtractor.filter1.setType(value)"></x-knob>
-      <x-knob id="filter-freq" name="Fiter Freq" value="22050" min="10" max="22050" oninput="subtractor.filter1.setFreq(value)"></x-knob>
-      <x-knob id="filter-q" name="Fiter Q" value="1" min="0" max="500" oninput="subtractor.filter1.setQ(value)"></x-knob>
-      <x-knob id="filter-gain" name="Fiter Gain" value="0" min="-40" max="40" oninput="subtractor.filter1.setGain(value)"></x-knob>
+      <x-knob id="filter-type" name="Fiter Type" value="1" min="1" max="8" observe="subtractor.filter1" bind="type"></x-knob>
+      <x-knob id="filter-freq" name="Fiter Freq" value="22050" min="10" max="22050" observe="subtractor.filter1" bind="freq"></x-knob>
+      <x-knob id="filter-q" name="Fiter Q" value="1" min="0" max="500" observe="subtractor.filter1" bind="q"></x-knob>
+      <x-knob id="filter-gain" name="Fiter Gain" value="0" min="-40" max="40" observe="subtractor.filter1" bind="gain"></x-knob>
     </section>
     <section>
       <h2>Master</h2>

--- a/demo/index.html
+++ b/demo/index.html
@@ -114,7 +114,7 @@
     </section>
     <section>
       <h2>Master</h2>
-      <x-fader id="lfo-type" name="Gain" value="50" min="1" max="100" oninput="subtractor.setMasterGain(value)"></x-fader>
+      <x-fader id="master-gain" name="Gain" value="50" min="1" max="100" observe="subtractor" bind="gain"></x-fader>
     </section>
     <canvas id="oscilloscope" class="oscilloscope"></canvas>
   </div>

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,72 +1,52 @@
-class Filter {
-    constructor(context, type=1, freq=22050, gain=0) {
+import { intToFilter, filterToInt } from './utils/helpers'
+import { Observable } from './Observe'
+
+class Filter extends Observable {
+    constructor(context) {
+      super()
       this.context = context
       this.filter = context.createBiquadFilter()
-
-      this.filterTypes = new Map([
-        [1, 'lowpass'],
-        [2, 'highpass'],
-        [3, 'bandpass'],
-        [4, 'lowshelf'],
-        [5, 'highshelf'],
-        [6, 'peaking'],
-        [7, 'notch'],
-        [8, 'allpass']
-      ])
-
-      this.setType(type)
-      this.setFreq(freq)
-      this.setGain(gain)
+      this.freq = 22050
+      this.type = 'lowpass'
     }
 
-    setType(value) {
+    set type(value) {
       if (typeof value == 'string') {
         this.filter.type = value
-      } else if (this.filterTypes.has(parseInt(value))) {
-        this.filter.type = this.filterTypes.get(parseInt(value))
-      } else {
-        throw Error(`Filter value ${value} not recognized`)
+      } else if (typeof value == 'number') {
+        this.filter.type = intToFilter(value)
       }
+      this.notifyObservers()
     }
 
-    setFreq(value) {
+    get type() {
+      return filterToInt(this.filter.type)
+    }
+
+    set freq(value) {
       this.filter.frequency.value = value
+      this.notifyObservers()
     }
 
-    setQ(value) {
-      this.filter.Q.value = value / 10
-    }
-
-    setGain(value) {
-      this.filter.gain.value = value
-    }
-
-    getType() {
-      return this.filter.type
-    }
-
-    getTypeInput() {
-      for (const [key, value] of this.filterTypes) {
-        if (value === this.getType()) {
-          return key
-        }
-      }
-      return 0
-    }
-
-    getFreq() {
+    get freq() {
       return this.filter.frequency.value
     }
 
-    getQ() {
+    set q(value) {
+      this.filter.Q.value = value
+      this.notifyObservers()
+    }
+
+    get q() {
       return this.filter.Q.value
     }
 
-    getQInput() {
-      return this.getQ() * 10
+    set gain(value) {
+      this.filter.gain.value = value
+      this.notifyObservers()
     }
 
-    getGain() {
+    get gain() {
       return this.filter.gain.value
     }
 }

--- a/src/Observe.js
+++ b/src/Observe.js
@@ -1,0 +1,27 @@
+class Observable {
+  constructor() {
+    self.observers = []
+  }
+
+  registerObserver(observer) {
+    self.observers.push(observer)
+  }
+
+  notifyObservers() {
+    self.observers.forEach(observer => {
+      observer.notify(this)
+    })
+  }
+}
+
+class Observer {
+  constructor(observable) {
+    observable.registerObserver(this)
+  }
+
+  notify(observable) {
+    console.log('Got update from', observable)
+  }
+}
+
+export { Observable, Observer }

--- a/src/Observe.js
+++ b/src/Observe.js
@@ -8,7 +8,7 @@ class Observable {
   }
 
   notifyObservers() {
-    self.observers.forEach(observer => {
+    self.observers.forEach((observer) => {
       observer.notify(this)
     })
   }

--- a/src/Osc.js
+++ b/src/Osc.js
@@ -1,14 +1,16 @@
 import { getNoteFreq } from './utils/maths'
 import { intToWaveform, waveformToInt } from './utils/helpers'
+import { Observable } from './Observe'
 
-class Osc {
+class Osc extends Observable {
     constructor(audioContext, enabled = true) {
+      super()
       this.audioContext = audioContext
-      this.enabled = enabled
-      this.waveform = 'sine'
-      this.octave = 0
-      this.semi = 0
-      this.detune = 0
+      this._enabled = enabled
+      this._waveform = 'sine'
+      this._octave = 0
+      this._semi = 0
+      this._detune = 0
     }
 
     // returns an array of oscillator nodes depending on the polyphony value
@@ -22,7 +24,7 @@ class Osc {
         // ternary gaurds interval being Infinity
 
       // shift the base note based on oscillator octave and semitone settings
-      const shiftedNote = note + (this.octave * 12) + this.semi
+      const shiftedNote = note + (this._octave * 12) + this._semi
       
       return Array(polyphony).fill()
         .map((_,i) => shiftedNote + (numIntervals - i) * interval)
@@ -31,53 +33,63 @@ class Osc {
         .map(this.startFreqOscillator.bind(this))
     }
 
-    startFreqOscillator(freq) {
+    startFreqOscillator(f) {
       const osc = this.audioContext.createOscillator()
-      osc.type = this.waveform
-      osc.frequency.value = freq
-      osc.detune.value = this.detune
+      osc.type = this._waveform
+      osc.frequency.value = f
+      osc.detune.value = this._detune
       osc.start()
       return osc
     }
 
-    setEnabled(value) {
-      this.enabled = value
+    set enabled(value) {
+      this._enabled = value
+      this.notifyObservers()
     }
 
-    setWaveform(value) {
-      this.waveform = intToWaveform(value)
+    get enabled() {
+      return this._enabled
     }
 
-    setOctave(value) {
-      this.octave = value
+    set waveform(value) {
+      if (typeof value == 'number') {
+        this._waveform = intToWaveform(value)
+      } else {
+        this._waveform = value
+      }
+      
+      this.notifyObservers()
     }
 
-    setSemi(value) {
-      this.semi = value
+    get waveform() {
+      return waveformToInt(this._waveform)
     }
 
-    setDetune(value) {
-      this.detune = value
+    set octave(value) {
+      this._octave = value
+      this.notifyObservers()
     }
 
-    getEnabled() {
-      return this.enabled
+    get octave() {
+      return this._octave
     }
 
-    getWaveform() {
-      return waveformToInt(this.waveform)
+    set semi(value) {
+      this._semi = value
+      this.notifyObservers()
     }
 
-    getOctave() {
-      return this.octave
+    get semi() {
+      return this._semi
     }
 
-    getSemi() {
-      return this.semi
+    set detune(value) {
+      this._detune = value
+      this.notifyObservers()
     }
 
-    getDetune() {
-      return this.detune
+    get detune() {
+      return this._detune
     }
 }
 

--- a/src/Subtractor.js
+++ b/src/Subtractor.js
@@ -7,6 +7,36 @@ import { Oscilloscope } from './Oscilloscope'
 import { keyboardKeys } from './utils/keyboard'
 
 
+class Observable {
+  constructor() {
+    self.observers = []
+  }
+
+  registerObserver(observer) {
+    self.observers.push(observer)
+  }
+
+  notifyObservers() {
+    self.observers.forEach(observer => {
+      observer.notify(this)
+    })
+  }
+}
+
+class Observer {
+  constructor(observable) {
+    observable.registerObserver(this)
+  }
+
+  notify(observable) {
+    console.log('Got update from', observable)
+  }
+}
+
+const subject = new Observable()
+const observer = new Observer(subject)
+subject.notifyObservers()
+
 class Subtractor {
   constructor() {
     this.context    = new AudioContext()

--- a/src/Subtractor.js
+++ b/src/Subtractor.js
@@ -22,23 +22,50 @@ class Subtractor extends Observable {
 
     // octave value is used only for the qwerty controls, this value should not be used
     // when MIDI is integrated. 
-    this.octave = 4
+    this._octave = 4
 
     // here polyphony refers to the number of oscs started for each key press,
     // detune refers to the spread of frequencies across the poly notes
-    this.polyphony = 1
-    this.detune = 0
+    this._polyphony = 1
+    this._detune = 0
 
     this.masterGain = this.context.createGain()
     this.filter1.filter.connect(this.masterGain)
     this.masterGain.connect(this.context.destination)
 
+    this.handleKeys()
+
     // only perform certain tasks once the DOM is ready
     document.addEventListener('DOMContentLoaded', () => {
       this.startOscilloscope()
       this.loadPreset(Presets.Init)
-      this.handleKeys()
     })
+  }
+
+  set octave(value) {
+    this._octave = value
+  }
+
+  get octave() {
+    return this._octave
+  }
+
+  set polyphony(value) {
+    this._polyphony = value
+    this.notifyObservers()
+  }
+
+  get polyphony() {
+    return this._polyphony
+  }
+
+  set detune(value) {
+    this._detune = value * .01
+    this.notifyObservers()
+  }
+
+  get detune() {
+    return this._detune * 100
   }
 
   set gain(value) {
@@ -48,15 +75,6 @@ class Subtractor extends Observable {
 
   get gain() {
     return this.masterGain.gain.value * 100
-  }
-
-  setPolyphony(value) {
-    this.polyphony = value
-    this.notifyObservers()
-  }
-
-  setDetune(value) {
-    this.detune = value / 100
   }
 
   handleKeys() {
@@ -101,7 +119,7 @@ class Subtractor extends Observable {
       if (!osc.enabled) { 
         return []
       }
-      return osc.start(note, this.polyphony, this.detune)
+      return osc.start(note, this._polyphony, this._detune)
                 .map(startedOsc => this.pipeline(startedOsc))
     })
 
@@ -136,57 +154,56 @@ class Subtractor extends Observable {
 
   // take a preset object and load it into the synth
   //
-  // in order to make this safe we define maps of how to set each preset 
-  // from the supplied preset object.
-  //
-  // there is a map of class attributes, e.g. `this.name`,
-  // and a map of functions to call, e.g. `this.osc1.setEnabled()`
-  //
-  // this is done to provide a safe mapping, where we can loop through
-  // and attempt to set each value without failing the entire operation
-  // with a global try block. If a preset value is missing, the outputs 
-  // a warning message.
-  //
-  loadPreset(preset) {
-    const presetValueMap = [
-      ['name', 'preset.name'],
-      ['author', 'preset.author'],
-      ['description', 'preset.description'],
-      ['gain', 'preset.settings.master.gain'],
-      ['polyphony', 'preset.settings.master.polyphony'],
-      ['detune', 'preset.settings.master.detune'],
-    ]
-    const presetFunctionMap = [
-      [this.osc1.setEnabled, this.osc1, 'preset.settings.osc1.enabled'],
-      [this.osc1.setWaveform, this.osc1, 'preset.settings.osc1.waveform'],
-      [this.osc1.setOctave, this.osc1, 'preset.settings.osc1.octave'],
-      [this.osc1.setSemi, this.osc1, 'preset.settings.osc1.semi'],
-      [this.osc1.setDetune, this.osc1, 'preset.settings.osc1.cent'],
-      [this.osc2.setEnabled, this.osc2, 'preset.settings.osc2.enabled'],
-      [this.osc2.setWaveform, this.osc2, 'preset.settings.osc2.waveform'],
-      [this.osc2.setOctave, this.osc2, 'preset.settings.osc2.octave'],
-      [this.osc2.setSemi, this.osc2, 'preset.settings.osc2.semi'],
-      [this.osc2.setDetune, this.osc2, 'preset.settings.osc2.cent'],
-      [this.filter1.setType, this.filter1, 'preset.settings.filter1.type'],
-      [this.filter1.setFreq, this.filter1, 'preset.settings.filter1.frequency'],
-      [this.filter1.setQ, this.filter1, 'preset.settings.filter1.q'],
-      [this.filter1.setGain, this.filter1, 'preset.settings.filter1.gain'],
-    ]
-
-    presetValueMap.forEach((value) => {
-      try {
-        this[value[0]] = eval(value[1])
-      } catch (e) {
-        console.warn(`Warning: ${value[1]} is missing from preset`)
-      }
-    })
-    presetFunctionMap.forEach((value) => {
-      try {
-        value[0].call(value[1], eval(value[2]))
-      } catch (e) {
-        console.warn(`Warning: ${value[2]} is missing from preset`)
-      }
-    })
+  loadPreset({
+    name = 'init',
+    author = '',
+    description = '',
+    master = {
+      gain: 50,
+      polyphony: 1,
+      detune: 0
+    },
+    osc1 = {
+      enabled: 1,
+      waveform: 1,
+      octave: 0,
+      semi: 0,
+      detune: 0
+    },
+    osc2 = {
+      enabled: 0,
+      waveform: 1,
+      octave: 0,
+      semi: 0,
+      detune: 0
+    },
+    filter1 = {
+      type: 1,
+      freq: 22050,
+      q: 0.10,
+      gain: 0
+    }
+  }) {
+    this.name = name
+    this.author = author
+    this.description = description
+    this.gain = master.gain
+    this.polyphony = master.polyphony
+    this.detune = master.detune
+    this.osc1.enabled = osc1.enabled
+    this.osc1.waveform = osc1.waveform
+    this.osc1.octave = osc1.octave
+    this.osc1.semi = osc1.semi
+    this.osc1.detune = osc1.detune
+    this.osc2.enabled = osc2.enabled
+    this.osc2.waveform = osc2.waveform
+    this.osc2.octave = osc2.octave
+    this.osc2.semi = osc2.semi
+    this.osc2.detune = osc2.detune
+    this.filter1.type = filter1.type
+    this.filter1.freq = filter1.freq
+    this.filter1.q = filter1.q
+    this.filter1.gain = filter1.gain
   }
 
   // take the current synth settings and return an object
@@ -196,32 +213,30 @@ class Subtractor extends Observable {
       'name': this.name,
       'author': this.author,
       'description': this.description,
-      'settings': { 
-        'master': { 'gain': this.gain },
-        'super': {
-          'polyphony': this.polyphony,
-          'detune': this.detune,
-        },
-        'osc1': {
-          'enabled': this.osc1.getEnabled(),
-          'waveform': this.osc1.getWaveform(),
-          'octave': this.osc1.getOctave(),
-          'semi': this.osc1.getSemi(),
-          'cent': this.osc1.getDetune()
-        },
-        'osc2': {
-          'enabled': this.osc2.getEnabled(),
-          'waveform': this.osc2.getWaveform(),
-          'octave': this.osc2.getOctave(),
-          'semi': this.osc2.getSemi(),
-          'cent': this.osc2.getDetune()
-        },
-        'filter1': {
-          'type': this.filter1.getType(),
-          'frequency': this.filter1.getFreq(),
-          'q': this.filter1.getQ(),
-          'gain': this.filter1.getGain()
-        }
+      'master': {
+        'gain': this.gain,
+        'polyphony': this.polyphony,
+        'detune': this.detune,
+      },
+      'osc1': {
+        'enabled': this.osc1.enabled,
+        'waveform': this.osc1.waveform,
+        'octave': this.osc1.octave,
+        'semi': this.osc1.semi,
+        'detune': this.osc1.detune
+      },
+      'osc2': {
+        'enabled': this.osc2.enabled,
+        'waveform': this.osc2.waveform,
+        'octave': this.osc2.octave,
+        'semi': this.osc2.semi,
+        'detune': this.osc2.detune
+      },
+      'filter1': {
+        'type': this.filter1.type,
+        'freq': this.filter1.freq,
+        'q': this.filter1.q,
+        'gain': this.filter1.gain
       }
     }
   }
@@ -261,10 +276,6 @@ class Subtractor extends Observable {
     a.click()
   }
 }
-
-// const subtractor = new Subtractor()
-// const observer = new Observer(subtractor)
-// subtractor.notifyObservers()
 
 export { Subtractor }
 window.Subtractor = Subtractor

--- a/src/components/Fader.js
+++ b/src/components/Fader.js
@@ -57,7 +57,6 @@ class Fader extends HTMLElement {
     this.maxTop = this.rangeRect.height - this.knobRect.height 
 
     this.setupEvents()
-
   }
 
   setupEvents() {

--- a/src/components/Fader.js
+++ b/src/components/Fader.js
@@ -2,17 +2,19 @@ import { pointToPercent } from '../utils/maths'
 import styles from '../sass/fader.scss';
 
 class Fader extends HTMLElement {
-  static get observedAttributes() {
-    return ['id', 'name', 'min', 'max', 'value',]
-  }
-
   connectedCallback() {
+    // if observable and bind attributes are preset, register this element as an observer
+    this.observable = eval(this.getAttribute('observe'))
+    this.bind = this.getAttribute('bind')
+    if (this.observable && this.bind) {
+      this.observable.registerObserver(this)
+    }
+    
     this.id = this.getAttribute('id')
     this.name = this.getAttribute('name')
     this.min = this.getAttribute('min')
     this.max = this.getAttribute('max')
     this.value = this.getAttribute('value')
-    this.oninput = new Function('value', this.getAttribute('oninput'))
     this.template = `
       <label for="fader__input" class="fader" id="fader">
         <input class="fader__input" id="fader__input" type="range" 
@@ -73,26 +75,26 @@ class Fader extends HTMLElement {
 
     this.faderInput.addEventListener('input', (e) => {
       const inputValue = parseInt(e.target.value)
-      const inputMax = parseInt(e.target.max)
-      const inputMin = parseInt(e.target.min) 
-      
-      const percent = pointToPercent(inputMin, inputMax, inputValue)
-      const top = this.maxTop * (1 - percent)
-      
-      this.faderKnob.style.top = `${parseInt(top)}px`
-      this.faderValue.innerText = inputValue
-
-      // call the oninput function passed in as an HTML attribute
-      this.oninput(parseInt(inputValue))
+      this.setTop(inputValue)
+      this.faderValue.innerText = parseInt(inputValue)
+      this.observable[this.bind] = parseInt(inputValue)
     })
+  }
 
-    this.faderInput.addEventListener('change', (e) => {
-      const inputValue = parseInt(e.target.value)
-      this.faderValue.innerText = inputValue
-    })
+  notify(observable) {
+    this.faderInput.value = this.observable[this.bind]
+    this.faderValue.innerText = parseInt(this.observable[this.bind])
+    this.setTop(this.observable[this.bind])
+  }
 
-    // trigger input event so `top` style is set in DOM
-    this.faderInput.dispatchEvent(new Event('input'))
+  setTop(inputValue) {
+    const inputMax = parseInt(this.faderInput.max)
+    const inputMin = parseInt(this.faderInput.min) 
+    
+    const percent = pointToPercent(inputMin, inputMax, inputValue)
+    const top = this.maxTop * (1 - percent)
+    
+    this.faderKnob.style.top = `${parseInt(top)}px`
   }
 
   mousemove (_this, x, y, oldValue, e) {

--- a/src/presets/Init.json
+++ b/src/presets/Init.json
@@ -1,34 +1,30 @@
 {
   "name": "Init",
-  "author": "",
+  "author": "Subtractor Team",
   "description": "",
-  "settings": {
-    "master": {
-      "gain": 50
-    },
-    "super": {
-      "polyphony": 1,
-      "detune": 0
-    },
-    "osc1": {
-      "enabled": 1,
-      "waveform": 1,
-      "octave": 0,
-      "semi": 0,
-      "cent": 0
-    },
-    "osc2": {
-      "enabled": 1,
-      "waveform": 1,
-      "octave": 0,
-      "semi": 0,
-      "cent": 0
-    },
-    "filter1": {
-      "type": "lowpass",
-      "frequency": 22050,
-      "q": 0.10000000149011612,
-      "gain": 0
-    }
+  "master": {
+    "gain": 50,
+    "polyphony": 1,
+    "detune": 0
+  },
+  "osc1": {
+    "enabled": 1,
+    "waveform": 1,
+    "octave": 0,
+    "semi": 0,
+    "detune": 0
+  },
+  "osc2": {
+    "enabled": 0,
+    "waveform": 1,
+    "octave": 0,
+    "semi": 0,
+    "detune": 0
+  },
+  "filter1": {
+    "type": 1,
+    "freq": 22050,
+    "q": 0.10,
+    "gain": 0
   }
 }

--- a/src/presets/Init.json
+++ b/src/presets/Init.json
@@ -1,34 +1,34 @@
 {
- "name": "",
- "author": "",
- "description": "",
- "settings": {
-  "master": {
-   "gain": 0.5
-  },
-  "super": {
-   "polyphony": 1,
-   "detune": 0
-  },
-  "osc1": {
-   "enabled": 1,
-   "waveform": 3,
-   "octave": 0,
-   "semi": 0,
-   "cent": 0
-  },
-  "osc2": {
-   "enabled": 0,
-   "waveform": 3,
-   "octave": 0,
-   "semi": 0,
-   "cent": 0
-  },
-  "filter1": {
-   "type": "lowpass",
-   "frequency": 22050,
-   "q": 0.10000000149011612,
-   "gain": 0
+  "name": "Init",
+  "author": "",
+  "description": "",
+  "settings": {
+    "master": {
+      "gain": 50
+    },
+    "super": {
+      "polyphony": 1,
+      "detune": 0
+    },
+    "osc1": {
+      "enabled": 1,
+      "waveform": 1,
+      "octave": 0,
+      "semi": 0,
+      "cent": 0
+    },
+    "osc2": {
+      "enabled": 1,
+      "waveform": 1,
+      "octave": 0,
+      "semi": 0,
+      "cent": 0
+    },
+    "filter1": {
+      "type": "lowpass",
+      "frequency": 22050,
+      "q": 0.10000000149011612,
+      "gain": 0
+    }
   }
- }
 }

--- a/src/presets/bass/DarkBass.json
+++ b/src/presets/bass/DarkBass.json
@@ -1,34 +1,30 @@
 {
- "name": "",
- "author": "",
- "description": "",
- "settings": {
+  "name": "Dark Bass",
+  "author": "Jon Sakas",
+  "description": "Not quite a reese but getting there",
   "master": {
-   "gain": 30
-  },
-  "super": {
-   "polyphony": 2,
-   "detune": 0.2
+    "gain": 30,
+    "polyphony": 2,
+    "detune": 0.2
   },
   "osc1": {
-   "enabled": 1,
-   "waveform": 2,
-   "octave": -2,
-   "semi": 0,
-   "cent": 0
+    "enabled": 1,
+    "waveform": 2,
+    "octave": -2,
+    "semi": 0,
+    "detune": 0
   },
   "osc2": {
-   "enabled": 1,
-   "waveform": 2,
-   "octave": -1,
-   "semi": 0,
-   "cent": 5
+    "enabled": 1,
+    "waveform": 2,
+    "octave": -1,
+    "semi": 0,
+    "detune": 5
   },
   "filter1": {
-   "type": "lowpass",
-   "frequency": 1553,
-   "q": 0.10000000149011612,
-   "gain": 0
+    "type": 1,
+    "freq": 2000,
+    "q": 0.10,
+    "gain": 0
   }
- }
 }

--- a/src/presets/bass/ElectroFifth.json
+++ b/src/presets/bass/ElectroFifth.json
@@ -1,34 +1,30 @@
 {
- "name": "",
- "author": "",
- "description": "",
- "settings": {
+  "name": "Electro Fifth",
+  "author": "Jon Sakas",
+  "description": "A fatty fifth",
   "master": {
-   "gain": 50
-  },
-  "super": {
-   "polyphony": 1,
-   "detune": 0
+    "gain": 50,
+    "polyphony": 1,
+    "detune": 0
   },
   "osc1": {
-   "enabled": 1,
-   "waveform": 3,
-   "octave": -2,
-   "semi": 0,
-   "cent": 0
+    "enabled": 1,
+    "waveform": 3,
+    "octave": -2,
+    "semi": 0,
+    "detune": 0
   },
   "osc2": {
-   "enabled": 1,
-   "waveform": 3,
-   "octave": 0,
-   "semi": 7,
-   "cent": 0
+    "enabled": 1,
+    "waveform": 3,
+    "octave": 0,
+    "semi": 7,
+    "detune": 0
   },
   "filter1": {
-   "type": "lowpass",
-   "frequency": 22050,
-   "q": 0.10000000149011612,
-   "gain": 0
+    "type": 1,
+    "freq": 22050,
+    "q": 0.10,
+    "gain": 0
   }
- }
 }

--- a/src/presets/synth/SuperFunk.json
+++ b/src/presets/synth/SuperFunk.json
@@ -1,34 +1,30 @@
 {
- "name": "",
- "author": "",
- "description": "",
- "settings": {
+  "name": "Super Funk",
+  "author": "Jon Sakas",
+  "description": "Play chords!",
   "master": {
-   "gain": 20
-  },
-  "super": {
-   "polyphony": 4,
-   "detune": 0.17
+    "gain": 20,
+    "polyphony": 4,
+    "detune": 0.17
   },
   "osc1": {
-   "enabled": 1,
-   "waveform": 3,
-   "octave": 0,
-   "semi": 0,
-   "cent": 0
+    "enabled": 1,
+    "waveform": 3,
+    "octave": 0,
+    "semi": 0,
+    "detune": 0
   },
   "osc2": {
-   "enabled": 1,
-   "waveform": 3,
-   "octave": 2,
-   "semi": 0,
-   "cent": 32
+    "enabled": 1,
+    "waveform": 3,
+    "octave": 2,
+    "semi": 0,
+    "detune": 32
   },
   "filter1": {
-   "type": "lowpass",
-   "frequency": 22050,
-   "q": 0,
-   "gain": 0
+    "type": 1,
+    "freq": 18010,
+    "q": 0,
+    "gain": 0
   }
- }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,36 @@
 
-const intToWaveform = function (i) {
-  return ['sine','square','sawtooth','triangle'][i - 1] || 'sine'
+const intToWaveform = function(i) {
+  return ['sine', 'square', 'sawtooth', 'triangle'][i - 1] || 'sine'
 }
 
-const waveformToInt = function (w) {
-  return ['sine','square','sawtooth','triangle'].indexOf(w) + 1
+const waveformToInt = function(w) {
+  return ['sine', 'square', 'sawtooth', 'triangle'].indexOf(w) + 1
 }
 
-export { intToWaveform, waveformToInt }
+const intToFilter = function(i) {
+  return [
+    'lowpass',
+    'highpass',
+    'bandpass',
+    'lowshelf',
+    'highshelf',
+    'peaking',
+    'notch',
+    'allpass'
+  ][i - 1] || 'lowpass'
+}
+
+const filterToInt = function(f) {
+  return [
+    'lowpass',
+    'highpass',
+    'bandpass',
+    'lowshelf',
+    'highshelf',
+    'peaking',
+    'notch',
+    'allpass'
+  ].indexOf(f) + 1
+}
+
+export { intToWaveform, waveformToInt, intToFilter, filterToInt }

--- a/tests/Filter.test.js
+++ b/tests/Filter.test.js
@@ -4,16 +4,13 @@ import { Filter } from '../src/Filter'
 test('Filter default type is lowpass', () => {
   const context = new AudioContext() 
   const filter = new Filter(context)
-  expect(filter.getType()).toBe('lowpass')
+  expect(filter.type).toBe(1)
 })
 
-test('Filter.setType() does not set invalid types', () => {
+test('Filter type does not allow invalid types', () => {
   const context = new AudioContext() 
   const filter = new Filter(context)
 
-  function setType() {
-    filter.setType(-1)
-  }
-
-  expect(setType).toThrowError(Error)
+  filter.type = -1
+  expect(filter.type).toBe(1)
 })

--- a/tests/Osc.test.js
+++ b/tests/Osc.test.js
@@ -14,32 +14,32 @@ describe('Osc', () => {
       getNoteFreq.mockImplementation(() => 440)
     })
 
-    test('calls getNoteFreq with 43 when note is 36, octave is 10, and semi is 7', () => {
+    test('calls getNoteFreq with 43 when note is 36, octave is 0, and semi is 7', () => {
       const osc = new Osc(audioContext)
-      osc.setOctave(0)
-      osc.setSemi(7)
+      osc.octave = 0
+      osc.semi = 7
       osc.start(36)
       expect(getNoteFreq.mock.calls[0][0]).toEqual(43)
     })
 
-    test('calls getNoteFreq with 55 when note is 36, octave is 10, and semi is 7', () => {
+    test('calls getNoteFreq with 55 when note is 36, octave is 1, and semi is 7', () => {
       const osc = new Osc(audioContext)
-      osc.setOctave(1)
-      osc.setSemi(7)
+      osc.octave = 1
+      osc.semi = 7
       osc.start(36)
       expect(getNoteFreq.mock.calls[0][0]).toEqual(55)
     })
 
     test('calls getNoteFreq with 60 when note is 36, octave is 2, and semi is 0', () => {
       const osc = new Osc(audioContext)
-      osc.setOctave(2)
+      osc.octave = 2
       osc.start(36)
       expect(getNoteFreq.mock.calls[0][0]).toEqual(60)
     })
 
     test('calls getNoteFreq with 0 when note is 36, octave is -3, and semi is 0', () => {
       const osc = new Osc(audioContext)
-      osc.setOctave(-3)
+      osc.octave = -3
       osc.start(36)
       expect(getNoteFreq.mock.calls[0][0]).toEqual(0)
     })

--- a/tests/Subtractor.test.js
+++ b/tests/Subtractor.test.js
@@ -5,18 +5,18 @@ import { Subtractor } from '../src/Subtractor'
 describe('Subtractor', () => {
   describe('qwerty keyboard', () => {
 
-    test('key "a" triggers note 39 when octave is 4', () => {
+    test('key "a" triggers note 36 when octave is 4', () => {
       const subtractor = new Subtractor()
       subtractor.startPolyNote = jest.fn()
-      subtractor.setOctave(3)
+      subtractor.octave = 3
       window.dispatchEvent(new KeyboardEvent('keydown', { 'key': 'a' }))
       expect(subtractor.startPolyNote.mock.calls[0]).toEqual([36])
     })
 
-     test('key "k" triggers note 39 when octave is 4', () => {
+     test('key "k" triggers note 36 when octave is 4', () => {
       const subtractor = new Subtractor()
       subtractor.startPolyNote = jest.fn()
-      subtractor.setOctave(3)
+      subtractor.octave = 3
       window.dispatchEvent(new KeyboardEvent('keydown', { 'key': 'k' }))
       expect(subtractor.startPolyNote.mock.calls[0]).toEqual([48])
     })
@@ -24,7 +24,7 @@ describe('Subtractor', () => {
     test('key "a" triggers note 48 when octave is 4', () => {
       const subtractor = new Subtractor()
       subtractor.startPolyNote = jest.fn()
-      subtractor.setOctave(4)
+      subtractor.octave = 4
       window.dispatchEvent(new KeyboardEvent('keydown', { 'key': 'a' }))
       expect(subtractor.startPolyNote.mock.calls[0]).toEqual([48])
     })
@@ -32,20 +32,14 @@ describe('Subtractor', () => {
      test('key "k" triggers note 60 when octave is 4', () => {
       const subtractor = new Subtractor()
       subtractor.startPolyNote = jest.fn()
-      subtractor.setOctave(4)
+      subtractor.octave = 4
       window.dispatchEvent(new KeyboardEvent('keydown', { 'key': 'k' }))
       expect(subtractor.startPolyNote.mock.calls[0]).toEqual([60])
     })
   })
 
   describe('loadPreset', () => {
-    // we anticipate this will cause a bunch of warnings, so we disable
-    // console.warn by mocking and then restore after the test
-    beforeEach(() => jest.spyOn(console, 'warn').mockImplementation())
-    afterEach(() => console.warn.mockRestore())
-
     test('can set a preset that is missing values', () => {
-
       const mockPreset = { 'description': 'This is a preset with no values :(' }
       const subtractor = new Subtractor()
 
@@ -58,32 +52,30 @@ describe('Subtractor', () => {
       'name': 'Rando Syntho',
       'author': 'Jon Sakas',
       'description': 'A bunch of random non-default values',
-      'settings': {
-        'master': { 
-          'gain': 75,
-          'polyphony': 3,
-          'detune': 1
-        },
-        'osc1': {
-          'enabled': 0,
-          'waveform': 3,
-          'octave': -2,
-          'semi': 3,
-          'cent': 27
-        },
-        'osc2': {
-          'enabled': 1,
-          'waveform': 2,
-          'octave': -1,
-          'semi': 5,
-          'cent': 23
-        },
-        'filter1': {
-          'type': 2,
-          'frequency': 10148,
-          'q': 1.5,
-          'gain': -3
-        }
+      'master': { 
+        'gain': 75,
+        'polyphony': 3,
+        'detune': 1
+      },
+      'osc1': {
+        'enabled': 0,
+        'waveform': 3,
+        'octave': -2,
+        'semi': 3,
+        'detune': 27
+      },
+      'osc2': {
+        'enabled': 1,
+        'waveform': 2,
+        'octave': -1,
+        'semi': 5,
+        'detune': 23
+      },
+      'filter1': {
+        'type': 2,
+        'freq': 10148,
+        'q': 0.15,
+        'gain': -3
       }
     }
     const subtractor = new Subtractor()
@@ -122,7 +114,7 @@ describe('Subtractor', () => {
     })
 
     test('sets osc1->waveform', () => {
-      expect(subtractor.osc1.waveform).toBe('sawtooth')
+      expect(subtractor.osc1.waveform).toBe(3)
     })
 
     test('sets osc1->octave', () => {
@@ -143,7 +135,7 @@ describe('Subtractor', () => {
     })
 
     test('sets osc2->waveform', () => {
-      expect(subtractor.osc2.waveform).toBe('square')
+      expect(subtractor.osc2.waveform).toBe(2)
     })
 
     test('sets osc2->octave', () => {


### PR DESCRIPTION
- Write Observable & Observer classes
- Make Subtractor a sub class of Observable
- Refactor Fader & Knob to be an Observer of Subtractor
- Refactor Subtractor, Osc, & Filter to use getters and setters
- Refactor preset loading to use destructuring for default options

The syntax for a fader no longer takes an `oninput` attribute, but an `observe` and `bind` attributes. The syntax looks like: 
```
<x-fader observe="subtractor" bind="gain" />
```

The `observe` should be the name of a reference to an `Observable` , the `bind` should be the name of an attribute which is set using `set` and `get` syntax. 

So an observable should be implemented like this:

```
class Subtractor extends Observable() {
  set gain() { 
    // set some stuff here, then
    this.notifyObservers()
  } 
}
```
closes: https://github.com/jsakas/Subtractor/issues/32