### PR TITLE
Move main styles in subtractor.scss and compile with webpack

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,64 +4,12 @@
 <head>
   <meta charset="utf-8">
   <title>Subtractor</title>
-  <style>
-    .subtractor {
-      display: inline-block;
-      user-select: none;
-    }
-
-    .oscilloscope {
-      display: block;
-      box-sizing: border-box;
-      width: 100%;
-      height: 150px;
-      margin-top: 5px;
-    }
-
-    .top {
-      display: flex;
-      align-items: center;
-    }
-
-    .logo {
-      display:inline-block;
-      flex: auto;
-    }
-
-    body {
-      font-family: sans-serif;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    section {
-      margin: 10px;
-      padding: 10px;
-      border: 1px solid green;
-      background: rgb(232, 241, 224);
-      display: inline-block;
-      margin: 0;
-      vertical-align: top;
-    }
-
-    .preset {
-      display: inline-block;
-    }
-
-    .preset h3 {
-      display: inline-block;
-    }
-
-    .preset .preset-select {
-      display: inline-block;
-    }
-  </style>
 </head>
 
 <body>
   <script src="../dist/subtractor.js" type="text/javascript"></script>
-
+  <link href="../dist/subtractor.css" rel="stylesheet" type="text/css">
+  
   <script>
     var subtractor = new Subtractor();
   </script>

--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
   "dependencies": {
     "@webcomponents/custom-elements": "^1.0.4",
     "@webcomponents/shadydom": "^1.0.4"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "\\.(css|scss)$": "<rootDir>/tests/__mocks__/css.js"
+    }
   }
 }

--- a/src/Subtractor.js
+++ b/src/Subtractor.js
@@ -1,4 +1,5 @@
 import * as Presets from './presets'
+import './sass/subtractor.scss';
 
 import { Osc } from './Osc'
 import { Filter } from './Filter'

--- a/src/sass/subtractor.scss
+++ b/src/sass/subtractor.scss
@@ -1,0 +1,52 @@
+.subtractor {
+  display: inline-block;
+  user-select: none;
+}
+
+.oscilloscope {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  height: 150px;
+  margin-top: 5px;
+}
+
+
+.top {
+  display: flex;
+  align-items: center;
+}
+
+.logo {
+  display: inline-block;
+  flex: auto;
+}
+
+body {
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+section {
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid green;
+  background: rgb(232, 241, 224);
+  display: inline-block;
+  margin: 0;
+  vertical-align: top;
+}
+
+.preset {
+  display: inline-block;
+}
+
+.preset h3 {
+  display: inline-block;
+}
+
+.preset .preset-select {
+  display: inline-block;
+}

--- a/tests/__mocks__/css.js
+++ b/tests/__mocks__/css.js
@@ -1,0 +1,3 @@
+// css files cannot be parsed by Node with Jest, so we mock them with an empty module.
+
+module.exports = {}

--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -1,4 +1,8 @@
 path = require('path')
+ExtractTextPlugin = require('extract-text-webpack-plugin')
+extractSass = new ExtractTextPlugin({
+    filename: 'subtractor.css'
+})
 
 module.exports =
     entry: [
@@ -32,9 +36,27 @@ module.exports =
             loader: 'json-loader'
         ,
             test: /\.scss$/,
-            use: [
-                loader: "css-loader" # translates CSS into CommonJS
-            ,
-                loader: "sass-loader" # compiles Sass to CSS  
+            include: [
+                path.resolve(__dirname, 'src/sass')
             ]
+            exclude: [
+                path.resolve(__dirname, 'src/sass/subtractor.scss')
+            ]
+            use: [
+                loader: 'css-loader'
+            ,
+                loader: 'sass-loader'
+            ]
+        ,
+            test: path.resolve(__dirname, 'src/sass/subtractor.scss'),
+            use: extractSass.extract(
+                use: [
+                    loader: 'css-loader'
+                ,
+                    loader: 'sass-loader'
+                ]
+            )
         ]
+    plugins: [
+        extractSass
+    ]


### PR DESCRIPTION
This is an interesting way to do this and I am not sure how scalable it is. For now it solves the issue of putting css inside of index.html. 

We will likely need to update the Webpack config depending on how the src/sass folder evolves. 

Closes https://github.com/jsakas/Subtractor/issues/26