### PR TITLE
Fix string based params label (filter type / osc waveform)

### DIFF
--- a/src/Filter.js
+++ b/src/Filter.js
@@ -16,11 +16,8 @@ class Filter extends Observable {
     }
 
     set type(value) {
-      if (typeof value == 'string') {
-        this._filter.type = value;
-      } else if (typeof value == 'number') {
-        this._filter.type = intToFilter(value);
-      }
+      console.log('set type', value);
+      this._filter.type = intToFilter(value);
       this.notifyObservers();
     }
 
@@ -28,21 +25,14 @@ class Filter extends Observable {
       return filterToInt(this._filter.type);
     }
 
-    get frType() {
-      return this._filter.type;
-    }
-
     set freq(value) {
+      console.log('set freq', value);
       this._filter.frequency.value = knobToFreq(value);
       this.notifyObservers();
     }
 
     get freq() {
       return freqToKnob(this._filter.frequency.value);
-    }
-
-    get frFreq() {
-      return this._filter.frequency.value;
     }
 
     set q(value) {

--- a/src/Osc.js
+++ b/src/Osc.js
@@ -62,10 +62,6 @@ class Osc extends Observable {
       return waveformToInt(this._waveform);
     }
 
-    get frWaveform() {
-      return this._waveform;
-    }
-
     set octave(value) {
       this._octave = Number(Number(value).toFixed());
       this.notifyObservers();

--- a/src/Subtractor.js
+++ b/src/Subtractor.js
@@ -3,7 +3,7 @@ import { Osc } from './Osc';
 import { Filter } from './Filter';
 import { Envelope } from './Envelope';
 import { knobToSeconds, knobToFreq } from './utils/maths';
-import { intToFilter, renameObjectKey, intToWaveform, waveformToInt } from './utils/helpers';
+import { renameObjectKey, intToWaveform, waveformToInt } from './utils/helpers';
 
 class Subtractor extends Observable {
   constructor() {
@@ -142,7 +142,7 @@ class Subtractor extends Observable {
 
     // create a filter, base it on the global filter
     const filter = new Filter(this.context);
-    filter.type = this.filter1.frType;
+    filter.type = this.filter1.type;
     filter.freq = this.filter1.freq;
     filter.q = this.filter1.q;
     filter.gain = this.filter1.gain;
@@ -417,18 +417,14 @@ class Subtractor extends Observable {
 
   // filter 1
   set filter1Type(value) {
-    this.filter1.type = intToFilter(value);
+    this.filter1.type = value;
     this.dynamicFilters.forEach((filter) => { 
-      filter.type = intToFilter(value); 
+      filter.type = value; 
     });
   }
 
   get filter1Type() {
     return this.filter1.type;
-  }
-
-  get filter1FrType() {
-    return this.filter1.frType;
   }
 
   set filter1Freq(value) {
@@ -440,10 +436,6 @@ class Subtractor extends Observable {
 
   get filter1Freq() {
     return this.filter1.freq;
-  }
-
-  get filter1FrFreq() {
-    return this.filter1.frFreq;
   }
 
   set filter1Q(value) {

--- a/src/components/Fader.js
+++ b/src/components/Fader.js
@@ -31,11 +31,20 @@ Vue.component('x-fader', {
       required: true,
       default: 127, 
     },
+    step: {
+      type: Number,
+      required: false,
+      default: 1,
+    },
     value: { 
       type: Number,
       required: true,
       default: 0,
     },
+    valueFmt: {
+      type: Function,
+      required: false,
+    }
   },
   methods: {
     mousedown(e) {
@@ -67,7 +76,7 @@ Vue.component('x-fader', {
         value = _this.min; 
       }
   
-      refs.faderInput.value = Number(value);
+      refs.faderInput.value = value;
       this.$emit('update:value', value);
     },
     onInput (e) {
@@ -84,9 +93,10 @@ Vue.component('x-fader', {
       let refs = this.$refs;
       refs.faderKnob.style.top = `${top}px`;
     },
-  },
-  filters: {
     label (value) {
+      if (this.valueFmt && typeof this.valueFmt == 'function') {
+        return this.valueFmt(value);
+      }
       return parseInt(value).toFixed(0);
     },
   },
@@ -99,6 +109,7 @@ Vue.component('x-fader', {
         type="range"
         :min="min"
         :max="max"
+        :step="step"
         :value="value"
         v-on:input="onInput"
       />
@@ -109,7 +120,7 @@ Vue.component('x-fader', {
       <div class="fader__name" id="fader__name">
         {{ name }}
       </div>
-      <div ref="faderValue" class="fader__value" id="fader__value">{{ value | label }}</div>
+      <div ref="faderValue" class="fader__value" id="fader__value">{{ this.label(value) }}</div>
     </label>
   `
 });

--- a/src/components/Knob.js
+++ b/src/components/Knob.js
@@ -28,17 +28,25 @@ Vue.component('x-knob', {
       required: true,
       default: 127, 
     },
+    step: {
+      type: Number,
+      required: false,
+      default: 1,
+    },
     value: { 
       type: Number,
       required: true,
       default: 0,
     },
+    valueFmt: {
+      type: Function,
+      required: false,
+    }
   },
   methods: {
     mousedown (e) {
       let refs = this.$refs;
 
-      // refs.knobInput.dispatchEvent(new Event('focus'));
       refs.knobKnob.style.transition = 'none';
       const currentValue = parseInt(refs.knobInput.value);
       const boundMousemove = this.mousemove.bind(e, this, e.clientX, e.clientY, currentValue);
@@ -49,6 +57,8 @@ Vue.component('x-knob', {
       });
     },
     mousemove (_this, x, y, oldValue, e) {
+      let refs = _this.$refs;
+
       const yDiff = (e.clientY - parseInt(y));
       const range = _this.max - _this.min;
       const changeInterval = range / 100;
@@ -61,12 +71,12 @@ Vue.component('x-knob', {
         value = _this.min; 
       }
 
-      // refs.knobInput.value = Number(value);
+      refs.knobInput.value = value;
       this.$emit('update:value', value);
     },
     onInput (e) {
-      // let value = Number(e.target.value);
-      // this.$emit('update:value', value);
+      let value = Number(e.target.value);
+      this.$emit('update:value', value);
     },
     setRotation(value = this.value) {
       let refs = this.$refs;
@@ -79,9 +89,10 @@ Vue.component('x-knob', {
   
       refs.knobKnob.style.transform = `rotateZ(${parseInt(degree)}deg)`;
     },
-  },
-  filters: {
     label (value) {
+      if (this.valueFmt && typeof this.valueFmt == 'function') {
+        return this.valueFmt(value);
+      }
       return parseInt(value).toFixed(0);
     },
   },
@@ -94,6 +105,7 @@ Vue.component('x-knob', {
         type="range" 
         :min="min"
         :max="max"
+        :step="step"
         :value="value"
         v-on:input="onInput"
       />
@@ -101,7 +113,7 @@ Vue.component('x-knob', {
         <div class="knob__knob" id="knob__knob" v-on:mousedown="this.mousedown" ref="knobKnob"></div>
       </div>
       <div class="knob__name" id="knob__name">{{ name }}</div>
-      <div class="knob__value" id="knob__value" ref="knobValue">{{ value | label }}</div>
+      <div class="knob__value" id="knob__value" ref="knobValue">{{ this.label(value) }}</div>
     </label>
   `
 });

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -33,7 +33,7 @@
       <div>
         <h2>Osc 1</h2>
         <x-knob id="enabled" name="On" :min="0" :max="1" v-bind:value.sync="subtractor.osc1.enabled"></x-knob>
-        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc1.waveform" label="frWaveform"></x-knob> 
+        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc1.waveform" :value-fmt="intToWaveform"></x-knob> 
         <x-knob id="octave" name="Octave" :min="-5" :max="5" v-bind:value.sync="subtractor.osc1.octave"></x-knob>
         <x-knob id="semi" name="Semi" :min="-12" :max="12" v-bind:value.sync="subtractor.osc1.semi"></x-knob>
         <x-knob id="voices" name="Voices" :min="1" :max="10" v-bind:value.sync="subtractor.osc1.voices"></x-knob>
@@ -42,7 +42,7 @@
       <div>
         <h2>Osc 2</h2>
         <x-knob id="enabled" name="On" :min="0" :max="1" v-bind:value.sync="subtractor.osc2.enabled"></x-knob>
-        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc2.waveform" label="frWaveform"></x-knob> 
+        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc2.waveform" :value-fmt="intToWaveform"></x-knob> 
         <x-knob id="octave" name="Octave" :min="-5" :max="5" v-bind:value.sync="subtractor.osc2.octave"></x-knob>
         <x-knob id="semi" name="Semi" :min="-12" :max="12" v-bind:value.sync="subtractor.osc2.semi"></x-knob>
         <x-knob id="voices" name="Voices" :min="1" :max="10" v-bind:value.sync="subtractor.osc2.voices"></x-knob>
@@ -51,7 +51,7 @@
       <div>
         <h2>Osc 3</h2>
         <x-knob id="enabled" name="On" :min="0" :max="1" v-bind:value.sync="subtractor.osc3.enabled"></x-knob>
-        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc3.waveform" label="frWaveform"></x-knob> 
+        <x-knob id="waveform" name="Waveform" :min="1" :max="4" v-bind:value.sync="subtractor.osc3.waveform" :value-fmt="intToWaveform"></x-knob> 
         <x-knob id="octave" name="Octave" :min="-5" :max="5" v-bind:value.sync="subtractor.osc3.octave"></x-knob>
         <x-knob id="semi" name="Semi" :min="-12" :max="12" v-bind:value.sync="subtractor.osc3.semi"></x-knob>
         <x-knob id="voices" name="Voices" :min="1" :max="10" v-bind:value.sync="subtractor.osc3.voices"></x-knob>
@@ -61,8 +61,8 @@
      <section>
       <div>
         <h2>Filter 1</h2>
-        <x-knob id="filter-type" name="Fiter Type" :min="1" :max="8" v-bind:value.sync="subtractor.filter1Type" label="filter1FrType"></x-knob>
-        <x-knob id="filter-freq" name="Fiter Freq" :min="0" :max="127" v-bind:value.sync="subtractor.filter1Freq" label="filter1FrFreq"></x-knob>
+        <x-knob id="filter-type" name="Fiter Type" :min="1" :max="8" v-bind:value.sync="subtractor.filter1Type" :value-fmt="intToFilter"></x-knob>
+        <x-knob id="filter-freq" name="Fiter Freq" :min="0" :max="127" v-bind:value.sync="subtractor.filter1Freq" :value-fmt="knobToFreq"></x-knob>
         <x-knob id="filter-q" name="Fiter Q" :min="0" :max="100" v-bind:value.sync="subtractor.filter1Q"></x-knob>
         <x-knob id="filter-gain" name="Fiter Gain" :min="-40" :max="40" v-bind:value.sync="subtractor.filter1Gain"></x-knob>
       </div>
@@ -78,14 +78,14 @@
     <section>
       <div>
         <h2>Filter 2</h2>
-        <x-knob id="filter-2-type" name="Fiter Type" :min="1" :max="8" v-bind:value.sync="subtractor.filter2.type" label="frType"></x-knob>
-        <x-knob id="filter-2-freq" name="Fiter Freq" :min="0" :max="127" v-bind:value.sync="subtractor.filter2.freq" label="frFreq"></x-knob>
+        <x-knob id="filter-2-type" name="Fiter Type" :min="1" :max="8" v-bind:value.sync="subtractor.filter2.type" :value-fmt="intToFilter"></x-knob>
+        <x-knob id="filter-2-freq" name="Fiter Freq" :min="0" :max="127" v-bind:value.sync="subtractor.filter2.freq" :value-fmt="knobToFreq"></x-knob>
         <x-knob id="filter-2-q" name="Fiter Q" :min="0" :max="100" v-bind:value.sync="subtractor.filter2.q"></x-knob>
         <x-knob id="filter-2-gain" name="Fiter Gain" :min="-40" :max="40" v-bind:value.sync="subtractor.filter2.gain"></x-knob>  
       </div>
       <div>
         <h2>Filter 2 LFO</h2>
-        <x-knob id="lfo-1-type" name="LFO Type" :min="1" :max="4" v-bind:value.sync="subtractor.lfo1Type" label="frlfo1Type"></x-knob>
+        <x-knob id="lfo-1-type" name="LFO Type" :min="1" :max="4" v-bind:value.sync="subtractor.lfo1Type" :value-fmt="intToWaveform"></x-knob>
         <x-knob id="lfo-1-freq" name="LFO Freq" :min="1" :max="2000" v-bind:value.sync="subtractor.lfo1Freq"></x-knob>
         <x-knob id="lfo-1-amount" name="LFO Amount" :min="0" :max="1000" v-bind:value.sync="subtractor.lfo1Amount"></x-knob>
       </div>

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import initOscilloscope from './Oscilloscope';
 import initQuertyController from './core/QwertyController';
 import initMidiController from './core/MidiController';
 import { loadPresetFile, savePresetFile } from './core/PresetFileController';
+import { intToWaveform, intToFilter } from './utils/helpers';
+import { knobToFreq } from './utils/maths';
 
 import presets from './presets';
 import defaultPreset from './presets/default';
@@ -47,7 +49,10 @@ new Vue({
     setPreset(e) {
       subtractor.loadPreset(this.preset);
       e.target.blur();
-    }
+    },
+    intToFilter,
+    intToWaveform,
+    knobToFreq,
   },
   data() {
     return {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,6 +1,7 @@
+const whole = n => Number(Number(n).toFixed());
 
 const intToWaveform = function(i) {
-  return ['sine', 'square', 'sawtooth', 'triangle'][i - 1] || 'sine';
+  return ['sine', 'square', 'sawtooth', 'triangle'][whole(i) - 1] || 'sine';
 };
 
 const waveformToInt = function(w) {
@@ -17,7 +18,7 @@ const intToFilter = function(i) {
     'peaking',
     'notch',
     'allpass'
-  ][i - 1] || 'lowpass';
+  ][whole(i).toFixed() - 1] || 'lowpass';
 };
 
 const filterToInt = function(f) {

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -67,7 +67,7 @@ export const knobToSeconds = function(value) {
 };
 
 export const knobToFreq = function(value) {
-  return Math.pow(value, 2);
+  return Number(Math.pow(value, 2).toFixed());
 };
 
 export const freqToKnob = function(value) {


### PR DESCRIPTION
Add ability to more easily transform UI input number values to the values needed for the Web Audio API. Some things are set using strings, like filter type `lowpass`, `highpass`, etc. Subtractor abstracts this into a number based system which is much easier to manage when the underlying values are coming from range inputs or controller knobs. 