### PR TITLE
Rewrite midi as MIDIController class and add UI controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {
+    "eventemitter3": "^3.1.2",
     "vue": "2.6.10"
   },
   "jest": {

--- a/src/Subtractor.scss
+++ b/src/Subtractor.scss
@@ -39,14 +39,18 @@ section {
   vertical-align: top;
 }
 
-.preset {
+.preset,
+.midi {
+  display: inline-block;
+  margin-left: 15px;
+}
+
+.preset h3,
+.midi h3 {
   display: inline-block;
 }
 
-.preset h3 {
-  display: inline-block;
-}
-
-.preset .preset-select {
+.preset .preset-select,
+.midi .midi-select {
   display: inline-block;
 }

--- a/src/core/MidiController.js
+++ b/src/core/MidiController.js
@@ -1,46 +1,95 @@
-const parseMIDIMessage = message => ({
-  command: message.data[0],
-  note: message.data[1],
-  velocity: message.data[2] / 127
+const EventEmitter = require('eventemitter3');
+
+const parseMIDIEvent = e => ({
+  command: e.data[0],
+  note: e.data[1],
+  velocity: e.data[2] / 127
 });
 
-const initMidiController = (subtractor) => {
-  if (!navigator || typeof navigator.requestMIDIAccess !== 'function') {
-    console.warn('navigator.requestMIDIAccess is not supported in this browser.');
-    return;
+class MidiController extends EventEmitter {
+  constructor() {
+    super();
+
+    this._inputs = [];
+    this._outputs = [];
+
+    this.getMIDIInputs = this.getMIDIInputs.bind(this);
+    this.getMIDIOutputs = this.getMIDIOutputs.bind(this);
+    this.configureMIDI = this.configureMIDI.bind(this);
+    this.handleMIDIStateChange = this.handleMIDIStateChange.bind(this);
+
+    navigator.requestMIDIAccess({ sysex: true })
+      .then(this.configureMIDI)
+      .then(this.getMIDIInputs)
+      .then(this.getMIDIOutputs)
+      .then(() => this.emit('update'))
+      .catch((e) => {
+        console.warn('Failed to initialize MidiController.', e);
+      });
+
   }
 
-  const handleMIDIStateChange = (e) => {
-    // print information about the (dis)connected MIDI controller
+  get inputs() {
+    return this._inputs;
+  }
+
+  get outputs () {
+    return this._outputs;
+  }
+
+  configureMIDI (midi) {
+    midi.onstatechange = this.handleMIDIStateChange;
+    return midi;
+  }
+
+  handleMIDIStateChange (e) {
     console.warn(e.port.name, e.port.manufacturer, e.port.state);
-  };
+    this.getMIDIInputs(e.target);
+    this.getMIDIOutputs(e.target);
+    this.emit('update');
+  }
 
-  const handleMIDIMessage = (message) => {
-    const m = parseMIDIMessage(message);
-    switch (m.command) {
-      case 144:
-        subtractor.noteOn(m.note, m.velocity);
-        break;
-      case 128:
-        subtractor.noteOff(m.note, m.velocity);
-        break;
-      default:
-        break;
+  getMIDIInputs (midi) {
+    this._inputs = [];
+    let inputs = midi.inputs.values();
+    for (let input = inputs.next(); input && !input.done; input = inputs.next()) {
+      this._inputs.push(input.value);
     }
-  };
 
-  navigator.requestMIDIAccess({ sysex: true })
-    .then((midi) => {
-      midi.onstatechange = handleMIDIStateChange;
+    return midi;
+  }
 
-      let inputs = midi.inputs.values();
-      for (let input = inputs.next(); input && !input.done; input = inputs.next()) {
-        input.value.onmidimessage = handleMIDIMessage;
-      }
-    })
-    .catch((e) => {
-      console.warn('Failed to initialize MIDI Controller.', e);
-    });
-};
+  getMIDIOutputs (midi) {
+    this._outputs = [];
+    let outputs = midi.outputs.values();
+    for (let output = outputs.next(); output && !output.done; output = outputs.next()) {
+      this._outputs.push(output.value);
+    }
 
-export default initMidiController;
+    return midi;
+  }
+
+  useInput (id) {
+    this._inputs
+      .forEach((input) => {
+        if (input.id === id) {
+          input.onmidimessage = (e) => {
+            const message = parseMIDIEvent(e);
+            this.handleMIDIMessage(message);
+          };
+        } else {
+          input.onmidimessage = () => null;
+        }
+      });
+  }
+
+  useOutput (id) {
+    // need to figure out how to properly route midi output
+  }
+
+  handleMIDIMessage (message) {
+    // this should be implemented by the user on the midi controller instance
+  }
+}
+
+export default MidiController;

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -10,6 +10,13 @@
   <div class="subtractor" id="subtractor">
     <div class="top">
       <h1 class="logo">Subtractor</h1>
+      <div class="midi">
+        <h3>Midi In</h3>
+        <select class="midi-select" @change="midi.useInput($event.target.value)">
+          <option value="off">---</option>
+          <option v-for="(input, key) in midi.inputs" :value="input.id">{{ input.name }}</option>
+        </select>
+      </div>
       <div class="preset">
         <h3>Preset</h3>
         <select class="preset-select" v-model="preset" @change="setPreset($event)">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,10 @@ eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
+eventemitter3@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "http://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"


### PR DESCRIPTION
This allows the user to select or deselect a midi input, enabling or disabling midi input from the controller.

This is immediately useful to me so I can compare this synth to other synths using the same keyboard. Currently if you have the webpage loaded there is no way to turn midi input off. 