### PR TITLE
Make osc notify active note oscs of changes

### DIFF
--- a/core/Subtractor.js
+++ b/core/Subtractor.js
@@ -82,7 +82,6 @@ class Subtractor extends Observable {
           this.osc2,
           this.osc3,
         ]
-        .filter(osc => osc.enabled)
         .map(osc => new Osc(this.context, osc))
         .map(osc => osc.start(note))
         .map(osc => this.pipeline(osc, velocity, osc.voices));

--- a/core/osc/Osc.test.js
+++ b/core/osc/Osc.test.js
@@ -17,6 +17,7 @@ describe('Osc', () => {
 
     test('calls maths.getNoteFreq with 43 when note is 36, octave is 0, and semi is 7', () => {
       new Osc(audioContext, {
+        enabled: true,
         octave: 0,
         semi: 7
       }).start(36);
@@ -26,6 +27,7 @@ describe('Osc', () => {
 
     test('calls maths.getNoteFreq with 55 when note is 36, octave is 1, and semi is 7', () => {
       new Osc(audioContext, {
+        enabled: true,
         octave: 1,
         semi: 7
       }).start(36);
@@ -35,6 +37,7 @@ describe('Osc', () => {
 
     test('calls maths.getNoteFreq with 60 when note is 36, octave is 2, and semi is 0', () => {
       new Osc(audioContext, {
+        enabled: true,
         octave: 2,
         semi: 0
       }).start(36);
@@ -44,6 +47,7 @@ describe('Osc', () => {
 
     test('calls maths.getNoteFreq with 0 when note is 36, octave is -3, and semi is 0', () => {
       new Osc(audioContext, {
+        enabled: true,
         octave: -3,
         semi: 0
       }).start(36);

--- a/core/utils/maths.js
+++ b/core/utils/maths.js
@@ -1,14 +1,22 @@
+// global tuning
+const TUNE = 440;
+
 // take a note, octave, and semi and shift it
 export const shiftNote = function(note, octave = 0, semi = 0) {
   return note + (octave * 12) + semi;
 };
 
 // take a note (keyboard key) and return the frequency
+// http://subsynth.sourceforge.net/midinote2freq.html
 //
 export const getNoteFreq = function(note) {
-  // http://subsynth.sourceforge.net/midinote2freq.html
-  const tune = 440;
-  return (tune / 32) * Math.pow(2, ((note - 9) / 12));
+  return (TUNE / 32) * Math.pow(2, ((note - 9) / 12));
+};
+
+// take a frequency and change it by n semitones
+// https://music.stackexchange.com/a/17567
+export const changeFreqBySemitones = function(freq, semitones) {
+  return Math.pow(2, semitones / 12) * freq;
 };
 
 // take voices and detune value and return an array of detune values
@@ -85,4 +93,3 @@ export const knobToFreq = function(value) {
 export const freqToKnob = function(value) {
   return Math.sqrt(value);
 };
-


### PR DESCRIPTION
If the second param to the Osc constructor is another Osc instance, make the newly created Osc an observer of the parent Osc, and notify if on change.

Closes https://github.com/jsakas/Subtractor/issues/60